### PR TITLE
adding Django CharField

### DIFF
--- a/bleachfields/__init__.py
+++ b/bleachfields/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
 from .bleachfield import BleachField
+from .bleachchar import BleachCharField
 from .bleachjson import BleachJSONField
 from .bleachtext import BleachTextField

--- a/bleachfields/bleachchar.py
+++ b/bleachfields/bleachchar.py
@@ -3,10 +3,10 @@ from django.db import models
 from .bleachfield import BleachField
 
 
-class BleachTextField(BleachField, models.TextField):
+class BleachCharField(BleachField, models.CharField):
 
     def pre_save(self, model_instance, add):
         new_value = getattr(model_instance, self.attname)
         clean_value = self.clean_text(new_value)
         setattr(model_instance, self.attname, clean_value)
-        return super(BleachTextField, self).pre_save(model_instance, add)
+        return super(BleachCharField, self).pre_save(model_instance, add)

--- a/bleachfields/bleachjson.py
+++ b/bleachfields/bleachjson.py
@@ -10,7 +10,7 @@ class BleachJSONField(BleachField, JSONField):
         new_value = getattr(model_instance, self.attname)
         clean_value = self._bleach_walk(new_value)
         setattr(model_instance, self.attname, clean_value)
-        return clean_value
+        return super(BleachJSONField, self).pre_save(model_instance, add)
 
     def _bleach_walk(self, node):
         cleaned = node

--- a/tests/bleachcharfield.py
+++ b/tests/bleachcharfield.py
@@ -1,0 +1,20 @@
+import unittest
+
+from bleachfields import BleachCharField
+
+
+class BleachCharFieldTest(unittest.TestCase):
+
+    def test_pre_save(self):
+        test_char_field = BleachCharField()
+        test_char_field.attname = 'number'
+
+        simple_html = '<span>123456789</span>'
+        simple_html_result = '123456789'
+
+        setattr(test_char_field, 'number', simple_html)
+
+        self.assertEqual(
+            test_char_field.pre_save(test_char_field, None),
+            simple_html_result
+        )


### PR DESCRIPTION
This is the field type that is needed for Django to enforce the max_length argument in model fields. Also, changing the pre_save methods to call the parent method after the attribute has been set.